### PR TITLE
Create modern portfolio layout

### DIFF
--- a/app/src/main/java/com/example/emptyviewsactivity/MainActivity.kt
+++ b/app/src/main/java/com/example/emptyviewsactivity/MainActivity.kt
@@ -4,20 +4,35 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
-import androidx.compose.material3.Scaffold
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.emptyviewsactivity.ui.theme.EmptyViewsActivityTheme
@@ -28,33 +43,420 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             EmptyViewsActivityTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        modifier = Modifier.padding(innerPadding)
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    PortfolioScreen()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PortfolioScreen(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        LazyColumn(
+            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            item { HeroSection() }
+            item { ExperienceSection(experiences = sampleExperiences) }
+            item { SkillsSection(skills = skillSet) }
+            item { ProjectsSection(projects = featuredProjects) }
+            item { ContactSection() }
+        }
+    }
+}
+
+@Composable
+private fun HeroSection(modifier: Modifier = Modifier) {
+    val gradient = Brush.verticalGradient(
+        colors = listOf(
+            MaterialTheme.colorScheme.primary,
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.92f),
+            MaterialTheme.colorScheme.secondary
+        )
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = MaterialTheme.colorScheme.background)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    brush = gradient,
+                    shape = RoundedCornerShape(28.dp)
+                )
+                .padding(28.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            AssistChip(
+                onClick = {},
+                label = { Text("モバイル × Web エンジニア") },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    labelColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = "Kenta Sato",
+                    style = MaterialTheme.typography.displaySmall,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+                Text(
+                    text = "Androidとフロントエンドを横断し、体験設計から実装・改善までをリードします。",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+                Text(
+                    text = "モバイルアプリを中心に10年以上の開発経験。ビジネスゴールとユーザー体験を両立させる開発体制づくりが得意です。",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Button(
+                    onClick = { /* TODO: open contact */ },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.onPrimary,
+                        contentColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text("最新の実績を見る")
+                }
+                OutlinedButton(
+                    onClick = { /* TODO: download resume */ },
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    ),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.6f))
+                ) {
+                    Text("職務経歴書を請求")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExperienceSection(experiences: List<Experience>, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        SectionTitle(
+            title = "経験",
+            description = "ユーザー価値とスピードを両立させるための開発と仕組み化を担当しました"
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            experiences.forEach { experience ->
+                ExperienceCard(experience = experience)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExperienceCard(experience: Experience, modifier: Modifier = Modifier) {
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 6.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = experience.role,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "${experience.company} ・ ${experience.period}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = experience.description,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            HighlightRow(highlights = experience.highlights)
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun HighlightRow(highlights: List<String>, modifier: Modifier = Modifier) {
+    if (highlights.isEmpty()) return
+
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        highlights.forEach { highlight ->
+            AssistChip(
+                onClick = {},
+                label = { Text(highlight) },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    labelColor = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun SkillsSection(skills: List<String>, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        SectionTitle(
+            title = "スキル",
+            description = "ビルドから運用までを支える技術群とプロダクト作りの知見"
+        )
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 4.dp)
+        ) {
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                skills.forEach { skill ->
+                    AssistChip(
+                        onClick = {},
+                        label = { Text(skill) },
+                        colors = AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            labelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
                     )
                 }
             }
         }
     }
 }
-@Composable
-fun Greeting(modifier: Modifier = Modifier) {
-    var isHello by remember { mutableStateOf(true) }
-    val displayText = if (isHello) "Hello Android!" else "ボタンを押しました！"
 
-    Column(modifier = modifier) {
-        Text(text = displayText)
-        Spacer(Modifier.height(16.dp))
-        Button(onClick = { isHello = !isHello }) {
-            Text(text = if (isHello) "押してみる" else "元に戻す")
+@Composable
+private fun ProjectsSection(projects: List<Project>, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        SectionTitle(
+            title = "プロジェクト",
+            description = "インハウス開発から共同開発まで、事業成長に直結する改善を行ってきました"
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            projects.forEach { project ->
+                ProjectCard(project = project)
+            }
         }
     }
 }
 
-@Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+private fun ProjectCard(project: Project, modifier: Modifier = Modifier) {
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        border = CardDefaults.outlinedCardBorder(),
+        shape = RoundedCornerShape(20.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(
+                text = project.name,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = project.stack,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = project.description,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = project.impact,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContactSection(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        SectionTitle(
+            title = "コンタクト",
+            description = "開発リード、技術顧問、チーム改善のご相談を歓迎しています"
+        )
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 4.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = "hello@yourname.dev",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = "GitHub: https://github.com/yourname",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "note: https://note.com/yourname",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(title: String, description: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+    }
+}
+
+@Immutable
+data class Experience(
+    val role: String,
+    val company: String,
+    val period: String,
+    val description: String,
+    val highlights: List<String>
+)
+
+@Immutable
+data class Project(
+    val name: String,
+    val stack: String,
+    val description: String,
+    val impact: String
+)
+
+private val sampleExperiences = listOf(
+    Experience(
+        role = "リードAndroidエンジニア",
+        company = "SmartRetail株式会社",
+        period = "2021 - 現在",
+        description = "Jetpack ComposeとKotlin Multiplatformでアプリ基盤を刷新し、リリースから半年で継続率を125%まで引き上げました。",
+        highlights = listOf("Jetpack Compose", "Kotlin", "KMP", "Design System", "Firebase", "Play Console 4.8★")
+    ),
+    Experience(
+        role = "フロントエンドエンジニア",
+        company = "SaaSスタートアップB",
+        period = "2018 - 2021",
+        description = "TypeScript + Next.jsでプロダクトのコア体験を実装。UXリサーチとグロース施策を並走し、CVRを1.6倍改善。",
+        highlights = listOf("TypeScript", "Next.js", "React", "Storybook", "A/Bテスト", "GraphQL")
+    ),
+    Experience(
+        role = "ソフトウェアエンジニア",
+        company = "エンタープライズ系企業C",
+        period = "2015 - 2018",
+        description = "Java/Kotlinとクラウドネイティブ基盤で業務システムを内製化。CI/CDパイプラインを構築し、デリバリーを週次に高速化。",
+        highlights = listOf("Java", "Spring", "Kotlin", "Docker", "Kubernetes", "CI/CD")
+    )
+)
+
+private val skillSet = listOf(
+    "Kotlin",
+    "Jetpack Compose",
+    "Kotlin Multiplatform",
+    "TypeScript",
+    "Next.js",
+    "React",
+    "Python",
+    "FastAPI",
+    "GraphQL",
+    "Design System",
+    "Firebase",
+    "AWS",
+    "Kubernetes",
+    "CI/CD",
+    "チームビルディング"
+)
+
+private val featuredProjects = listOf(
+    Project(
+        name = "SmartRetail Companion App",
+        stack = "Kotlin / Compose / Firebase / Cloud Run",
+        description = "在庫管理と分析をワンストップで行うリテール向けモバイルアプリ。店舗スタッフが日常で使える体験設計を主導しました。",
+        impact = "β版から本番までリードし、NPS +18pt・オペレーションコスト20%削減を達成。"
+    ),
+    Project(
+        name = "Realtime Analytics Dashboard",
+        stack = "TypeScript / Next.js / GraphQL / Hasura",
+        description = "ビジネス指標をリアルタイムで可視化するダッシュボード。プロダクトオーナーと共創し、意思決定のリードタイムを短縮。",
+        impact = "リリース後3ヶ月でMAUが2.2倍、KPIのモニタリング工数を60%削減。"
+    ),
+    Project(
+        name = "DataOps Automation Suite",
+        stack = "Python / Airflow / AWS",
+        description = "データパイプラインの自動化と監視を統合したプラットフォーム。異常検知とセルフヒーリング機構を実装。",
+        impact = "1年で障害件数を70%削減し、データ活用のサイクルを高速化。"
+    )
+)
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun PortfolioPreview() {
     EmptyViewsActivityTheme {
-        Greeting()
+        PortfolioScreen()
     }
 }

--- a/app/src/main/java/com/example/emptyviewsactivity/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/emptyviewsactivity/ui/theme/Color.kt
@@ -2,10 +2,21 @@ package com.example.emptyviewsactivity.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+val Indigo700 = Color(0xFF1E40AF)
+val Indigo600 = Color(0xFF2563EB)
+val Indigo400 = Color(0xFF4F46E5)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val Cyan500 = Color(0xFF22D3EE)
+val Cyan300 = Color(0xFF67E8F9)
+
+val Coral500 = Color(0xFFF97316)
+val Coral200 = Color(0xFFFECBA1)
+
+val Mist = Color(0xFFF8FAFC)
+val PureWhite = Color(0xFFFFFFFF)
+val Slate900 = Color(0xFF0F172A)
+val Slate800 = Color(0xFF1E293B)
+val Slate400 = Color(0xFF94A3B8)
+val Slate200 = Color(0xFFE2E8F0)
+val Slate300 = Color(0xFFCBD5F5)
+val Slate600 = Color(0xFF475569)

--- a/app/src/main/java/com/example/emptyviewsactivity/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/emptyviewsactivity/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.example.emptyviewsactivity.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -9,34 +8,56 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = Indigo400,
+    onPrimary = PureWhite,
+    primaryContainer = Indigo700,
+    onPrimaryContainer = Slate300,
+    secondary = Cyan300,
+    onSecondary = Slate900,
+    secondaryContainer = Color(0xFF134E5B),
+    onSecondaryContainer = Cyan300,
+    tertiary = Coral200,
+    onTertiary = Slate900,
+    tertiaryContainer = Color(0xFF5F2A0C),
+    onTertiaryContainer = Coral200,
+    background = Slate900,
+    onBackground = Mist,
+    surface = Color(0xFF111827),
+    onSurface = Mist,
+    surfaceVariant = Color(0xFF1F2937),
+    onSurfaceVariant = Slate300,
+    outline = Slate600
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = Indigo600,
+    onPrimary = PureWhite,
+    primaryContainer = Indigo400,
+    onPrimaryContainer = Slate900,
+    secondary = Cyan500,
+    onSecondary = Slate900,
+    secondaryContainer = Color(0xFFE0F7FF),
+    onSecondaryContainer = Slate900,
+    tertiary = Coral500,
+    onTertiary = PureWhite,
+    tertiaryContainer = Color(0xFFFFD7BA),
+    onTertiaryContainer = Color(0xFF311200),
+    background = Mist,
+    onBackground = Slate900,
+    surface = PureWhite,
+    onSurface = Slate900,
+    surfaceVariant = Slate200,
+    onSurfaceVariant = Slate600,
+    outline = Slate400
 )
 
 @Composable
 fun EmptyViewsActivityTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {

--- a/app/src/main/java/com/example/emptyviewsactivity/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/emptyviewsactivity/ui/theme/Type.kt
@@ -6,29 +6,54 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
 val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 40.sp,
+        lineHeight = 46.sp,
+        letterSpacing = (-0.5).sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 28.sp,
+        lineHeight = 34.sp,
+        letterSpacing = (-0.25).sp
+    ),
     titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 22.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp
     ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
+        fontSize = 18.sp,
+        lineHeight = 26.sp,
+        letterSpacing = 0.1.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 26.sp,
+        letterSpacing = 0.2.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 22.sp,
+        letterSpacing = 0.2.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 13.sp,
+        lineHeight = 18.sp,
         letterSpacing = 0.5.sp
     )
-    */
 )


### PR DESCRIPTION
## Summary
- build a Jetpack Compose portfolio screen with hero, experience, skill, project, and contact sections
- add immutable models and curated sample content to showcase Android and web expertise
- refresh Material 3 color palette and typography to deliver a clean, modern visual style

## Testing
- `bash ./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d2953e8054832c9cfa1b729cc61194