### PR TITLE
Annotate SkillsSection with ExperimentalLayoutApi opt-in

### DIFF
--- a/app/src/main/java/com/example/emptyviewsactivity/MainActivity.kt
+++ b/app/src/main/java/com/example/emptyviewsactivity/MainActivity.kt
@@ -218,6 +218,7 @@ private fun HighlightRow(highlights: List<String>, modifier: Modifier = Modifier
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SkillsSection(skills: List<String>, modifier: Modifier = Modifier) {
     Column(


### PR DESCRIPTION
## Summary
- opt in to ExperimentalLayoutApi for the SkillsSection composable so its FlowRow usage is covered

## Testing
- ./gradlew build *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d29b059830832cb84e27411ed87c46